### PR TITLE
:sparkles: feat: create payment fragment layout

### DIFF
--- a/app/src/main/java/com/example/autoclean/ui/payment/CardPaymentFragment.kt
+++ b/app/src/main/java/com/example/autoclean/ui/payment/CardPaymentFragment.kt
@@ -1,0 +1,30 @@
+package com.example.autoclean.ui.payment
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.example.autoclean.databinding.FragmentCardPaymentBinding
+
+
+
+class CardPaymentFragment : Fragment() {
+
+    private var _binding: FragmentCardPaymentBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentCardPaymentBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+}

--- a/app/src/main/res/layout/fragment_card_payment.xml
+++ b/app/src/main/res/layout/fragment_card_payment.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.payment.CardPaymentFragment">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <include
+            android:id="@+id/include6"
+            layout="@layout/fragment_header"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="0dp"
+            android:paddingTop="0dp"
+            android:paddingBottom="0dp" />
+
+        <LinearLayout
+            android:id="@+id/linearLayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="270dp"
+            android:background="@drawable/rounded_top_border"
+            android:orientation="vertical"
+            android:paddingBottom="16dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_standard"
+                android:fontFamily="@font/inter"
+                android:gravity="center"
+                android:lineHeight="@dimen/line_height_large"
+                android:text="@string/payment_title"
+                android:textColor="@color/primary_variant2"
+                android:textSize="@dimen/text_size_large"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_standard"
+                android:layout_marginTop="@dimen/margin_standard"
+                android:fontFamily="@font/inter"
+                android:text="@string/card_number"
+                android:textColor="@color/primary_variant2"
+                android:textStyle="bold" />
+
+            <EditText
+                style="@style/PrimaryEditText"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/button_height"
+                android:layout_marginHorizontal="@dimen/margin_standard"
+                android:layout_marginTop="@dimen/default_padding"
+                android:hint="@string/card_number_hint" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_standard"
+                android:layout_marginTop="@dimen/margin_standard"
+                android:fontFamily="@font/inter"
+                android:text="@string/card_holder_name"
+                android:textColor="@color/primary_variant2"
+                android:textStyle="bold" />
+
+            <EditText
+                style="@style/PrimaryEditText"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/button_height"
+                android:layout_marginHorizontal="@dimen/margin_standard"
+                android:layout_marginTop="@dimen/default_padding"
+                android:hint="@string/card_holder_hint" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginHorizontal="@dimen/margin_standard">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginTop="@dimen/margin_standard"
+                    android:fontFamily="@font/inter"
+                    android:text="@string/validity_date"
+                    android:textColor="@color/primary_variant2"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginTop="@dimen/margin_standard"
+                    android:fontFamily="@font/inter"
+                    android:text="@string/cvv"
+                    android:textColor="@color/primary_variant2"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="@dimen/default_padding"
+                android:layout_marginHorizontal="@dimen/margin_standard">
+
+                <EditText
+                    style="@style/PrimaryEditText"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/button_height"
+                    android:layout_weight="1"
+                    android:hint="@string/validity_date_hint"
+                    android:layout_marginEnd="@dimen/default_padding" />
+
+                <EditText
+                    style="@style/PrimaryEditText"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/button_height"
+                    android:layout_weight="1"
+                    android:hint="@string/cvv_hint" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginHorizontal="@dimen/margin_standard"
+                android:layout_marginTop="@dimen/default_padding">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_standard"
+                    android:fontFamily="@font/inter"
+                    android:text="@string/installments"
+                    android:textColor="@color/primary_variant2"
+                    android:textStyle="bold" />
+
+                <EditText
+                    style="@style/PrimaryEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/button_height"
+                    android:layout_marginTop="@dimen/default_padding"
+                    android:hint="@string/installments_hint"
+                    android:drawableEnd="@drawable/ic_arrow_down" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_continue"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/button_height"
+                    android:layout_marginTop="@dimen/tab_indicator_height"
+                    android:text="@string/btn_continue"
+                    style="@style/PrimaryButton" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </FrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,4 +9,11 @@
     <dimen name="tab_indicator_height">4dp</dimen>
 
 
+    <dimen name="text_size_large">32sp</dimen>
+    <dimen name="line_height_large">36sp</dimen>
+    <dimen name="margin_standard">16dp</dimen>
+    <dimen name="margin_horizontal">32dp</dimen>
+    <dimen name="margin_vertical">16dp</dimen>
+    <dimen name="button_height">48dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,4 +85,17 @@
     <string name="cleaning_kit_title">Cleaning Kit</string>
     <string name="choose_kit_title">Choose Kit</string>
 
+    <!-- Card Payment -->
+    <string name="payment_title">Pagamento</string>
+    <string name="card_number">Número do Cartão</string>
+    <string name="card_number_hint">0000 0000 0000 0000</string>
+    <string name="card_holder_name">Nome no Cartão</string>
+    <string name="card_holder_hint">Nome como escrito no cartão</string>
+    <string name="validity_date">Data de Validade</string>
+    <string name="validity_date_hint">MM/AA</string>
+    <string name="cvv">CVV</string>
+    <string name="cvv_hint">123</string>
+    <string name="installments">Parcelamento</string>
+    <string name="installments_hint">Em 1x de R$ 3000,00</string>
+
 </resources>


### PR DESCRIPTION
- Adds an initial layout for the payment processing fragment.
- Includes centralized string references in  for easier internationalization.
- Utilizes standardized dimensions from  for visual consistency and responsiveness.
- Sets up input fields and buttons with a consistent and intuitive style.