### PR TITLE
:sparkles: feat: implement passing of args between fragments for user…

### DIFF
--- a/app/src/main/java/com/example/autoclean/ui/auth/profile/ProfileProfissionalFragment.kt
+++ b/app/src/main/java/com/example/autoclean/ui/auth/profile/ProfileProfissionalFragment.kt
@@ -275,7 +275,12 @@ class ProfileProfissionalFragment : Fragment() {
                 if (response.isSuccessful) {
                     Log.d(TAG, "User data saved successfully via API!")
                     Toast.makeText(requireContext(), "Informações enviadas com sucesso!", Toast.LENGTH_SHORT).show()
-                    findNavController().navigate(R.id.action_profileProfissionalFragment_to_professionalVerificationFragment)
+
+                    val action = ProfileProfissionalFragmentDirections.actionProfileProfissionalFragmentToProfessionalVerificationFragment(
+                        displayName = registrationData.fullname
+                    )
+                    findNavController().navigate(action)
+
                 } else {
                     val errorBody = response.errorBody()?.string()
                     if (errorBody != null) {

--- a/app/src/main/java/com/example/autoclean/ui/auth/verification/PhoneVerificationStartFragment.kt
+++ b/app/src/main/java/com/example/autoclean/ui/auth/verification/PhoneVerificationStartFragment.kt
@@ -77,7 +77,7 @@ class PhoneVerificationStartFragment : Fragment() {
     private fun initListeners() {
 
         val countryCode = "+XX"
-        val phoneNumber = "900000001"
+        val phoneNumber = "900000004"
         val fullPhoneNumber = "$countryCode$phoneNumber"
 
         binding.btnContinue.setOnClickListener {

--- a/app/src/main/java/com/example/autoclean/ui/auth/verification/ProfessionalVerificationFragment.kt
+++ b/app/src/main/java/com/example/autoclean/ui/auth/verification/ProfessionalVerificationFragment.kt
@@ -6,12 +6,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.example.autoclean.R
 import com.example.autoclean.databinding.FragmentProfessionalVerificationBinding
 
 class ProfessionalVerificationFragment : Fragment() {
     private var _binding: FragmentProfessionalVerificationBinding? = null
     private val binding get() = _binding!!
+
+    private val args: ProfessionalVerificationFragmentArgs by navArgs()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -25,7 +28,7 @@ class ProfessionalVerificationFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         initListeners()
-        updateUserName("Carlos")
+        updateUserName(args.displayName)
     }
 
     private fun initListeners() {

--- a/app/src/main/res/navigation/main_graph.xml
+++ b/app/src/main/res/navigation/main_graph.xml
@@ -179,6 +179,9 @@
         android:name="com.example.autoclean.ui.auth.verification.ProfessionalVerificationFragment"
         android:label="fragment_professional_verification"
         tools:layout="@layout/fragment_professional_verification" >
+        <argument
+            android:name="displayName"
+            app:argType="string" />
         <action
             android:id="@+id/action_professionalVerificationFragment_to_cleaningkitmanagerFragment"
             app:destination="@id/cleaningkitmanagerFragment" />


### PR DESCRIPTION
…name display

- Implemented the transfer of arguments between fragments to enable displaying the username across different screens.
- Updated ProfileProfissionalFragment.kt to handle and display username args.
- Modified PhoneVerificationStartFragment.kt and ProfessionalVerificationFragment.kt to correctly pass username information.
- Adjusted main_graph.xml to support the navigation of username args between fragments.